### PR TITLE
fix: resolve static asset paths relative to markdown file directory

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { SidebarResizeHandle } from './components/SidebarResizeHandle'
 import { FileTree } from './components/FileTree'
 import { MarkdownContent } from './components/MarkdownContent'
 import { buildFileTree, type ApiFile } from './utils/fileTree'
+import { rewriteImagePaths } from './utils/htmlRewriter'
 import './App.css'
 import './CodeBlockEnhancements.css'
 
@@ -19,22 +20,6 @@ function wrapTablesForScroll(html: string): string {
   return html
     .replace(/<table>/g, '<div class="table-wrapper"><table>')
     .replace(/<\/table>/g, '</table></div>')
-}
-
-// Helper function to rewrite relative image paths to use /api/static/
-function rewriteImagePaths(html: string, cacheBust = false): string {
-  // Rewrite relative image paths to use /api/static/
-  // This handles src="image.png" -> src="/api/static/image.png"
-  // And src="path/to/image.png" -> src="/api/static/path/to/image.png"
-  // Add cache-busting parameter if needed (for image reloads)
-  const timestamp = cacheBust ? `?t=${Date.now()}` : ''
-  return html.replace(/<img([^>]*)\s+src="([^":/]+[^":]*)"/g, (match, attrs, src) => {
-    // Only rewrite if it's a relative path (doesn't start with http://, https://, or /)
-    if (!src.startsWith('http://') && !src.startsWith('https://') && !src.startsWith('/')) {
-      return `<img${attrs} src="/api/static/${src}${timestamp}"`
-    }
-    return match
-  })
 }
 
 function App() {
@@ -67,8 +52,8 @@ function App() {
           let html = marked.parse(data.markdown) as string
           // Wrap tables for horizontal scrolling
           html = wrapTablesForScroll(html)
-          // Rewrite relative image paths to use /api/static/
-          html = rewriteImagePaths(html, cacheBustImages)
+          // Rewrite relative image paths to use /api/static/ with correct directory context
+          html = rewriteImagePaths(html, path, cacheBustImages)
           setContent(html)
           setCurrentPath(path)
           currentPathRef.current = path

--- a/frontend/src/components/MarkdownContent.test.tsx
+++ b/frontend/src/components/MarkdownContent.test.tsx
@@ -149,4 +149,53 @@ describe('MarkdownContent', () => {
       expect(link?.getAttribute('href')).toBe('../root.md')
     })
   })
+
+  describe('relative asset link handling', () => {
+    it('should rewrite PDF link href to use /api/static/ with directory context', () => {
+      const html = '<p><a href="document.pdf">Open PDF</a></p>'
+
+      const { container } = render(<MarkdownContent html={html} filePath="docs/guide/page.md" />)
+
+      const link = container.querySelector('a')
+      expect(link).toBeTruthy()
+      expect(link?.getAttribute('href')).toBe('/api/static/docs/guide/document.pdf')
+    })
+
+    it('should rewrite nested asset link with directory context', () => {
+      const html = '<p><a href="assets/file.pdf">Download</a></p>'
+
+      const { container } = render(<MarkdownContent html={html} filePath="course/unit1/page.md" />)
+
+      const link = container.querySelector('a')
+      expect(link?.getAttribute('href')).toBe('/api/static/course/unit1/assets/file.pdf')
+    })
+
+    it('should rewrite asset link for root-level file', () => {
+      const html = '<p><a href="doc.pdf">PDF</a></p>'
+
+      const { container } = render(<MarkdownContent html={html} filePath="readme.md" />)
+
+      const link = container.querySelector('a')
+      expect(link?.getAttribute('href')).toBe('/api/static/doc.pdf')
+    })
+
+    it('should NOT rewrite external URLs', () => {
+      const html = '<p><a href="https://example.com/doc.pdf">External PDF</a></p>'
+
+      const { container } = render(<MarkdownContent html={html} filePath="docs/page.md" />)
+
+      const link = container.querySelector('a')
+      expect(link?.getAttribute('href')).toBe('https://example.com/doc.pdf')
+    })
+
+    it('should open asset links in a new tab', () => {
+      const html = '<p><a href="document.pdf">Open PDF</a></p>'
+
+      const { container } = render(<MarkdownContent html={html} filePath="docs/page.md" />)
+
+      const link = container.querySelector('a')
+      expect(link?.getAttribute('target')).toBe('_blank')
+      expect(link?.getAttribute('rel')).toBe('noopener noreferrer')
+    })
+  })
 })

--- a/frontend/src/components/MarkdownContent.tsx
+++ b/frontend/src/components/MarkdownContent.tsx
@@ -3,6 +3,7 @@ import { CodeBlock } from './CodeBlock'
 import { MermaidDiagram } from './MermaidDiagram'
 import { TodoCheckbox } from './TodoCheckbox'
 import { resolveRelativePath, isRelativeMarkdownLink } from '../utils/pathResolver'
+import { isRelativeAssetLink, getDirectory } from '../utils/htmlRewriter'
 
 interface MarkdownContentProps {
   html: string
@@ -95,11 +96,12 @@ export const MarkdownContent = memo(function MarkdownContent({
         }
       }
 
-      // Handle anchor tags for relative markdown links
-      if (tagName === 'a' && onLinkClick) {
+      // Handle anchor tags
+      if (tagName === 'a') {
         const href = element.getAttribute('href')
-        if (href && isRelativeMarkdownLink(href)) {
-          // This is a relative markdown link - handle it specially
+
+        // Handle relative markdown links (in-app navigation)
+        if (href && onLinkClick && isRelativeMarkdownLink(href)) {
           const resolvedPath = resolveRelativePath(filePath, href)
 
           // Get all children
@@ -128,6 +130,37 @@ export const MarkdownContent = memo(function MarkdownContent({
             e.preventDefault()
             onLinkClick(resolvedPath)
           }
+
+          return createElement('a', props, ...children)
+        }
+
+        // Handle relative asset links (PDFs, images, etc.) - rewrite to /api/static/
+        if (href && isRelativeAssetLink(href)) {
+          const dir = getDirectory(filePath)
+          const prefix = dir ? `${dir}/` : ''
+          const staticHref = `/api/static/${prefix}${href}`
+
+          const children = Array.from(element.childNodes).map((child, i) =>
+            convertNodeToReact(child, i)
+          )
+
+          const props: Record<string, unknown> = { key }
+          for (let i = 0; i < element.attributes.length; i++) {
+            const attr = element.attributes[i]
+            if (attr && attr.name !== 'href') {
+              if (attr.name === 'class') {
+                props.className = attr.value
+              } else if (attr.name === 'style') {
+                props.style = parseStyleString(attr.value)
+              } else {
+                props[attr.name] = attr.value
+              }
+            }
+          }
+
+          props.href = staticHref
+          props.target = '_blank'
+          props.rel = 'noopener noreferrer'
 
           return createElement('a', props, ...children)
         }

--- a/frontend/src/utils/htmlRewriter.test.ts
+++ b/frontend/src/utils/htmlRewriter.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { getDirectory, rewriteImagePaths, isRelativeAssetLink } from './htmlRewriter'
+
+describe('getDirectory', () => {
+  it('should extract directory from nested path', () => {
+    expect(getDirectory('dir/subdir/file.md')).toBe('dir/subdir')
+  })
+
+  it('should extract directory from single level path', () => {
+    expect(getDirectory('dir/file.md')).toBe('dir')
+  })
+
+  it('should return empty string for root-level file', () => {
+    expect(getDirectory('file.md')).toBe('')
+  })
+
+  it('should handle deeply nested paths', () => {
+    expect(getDirectory('a/b/c/d/file.md')).toBe('a/b/c/d')
+  })
+})
+
+describe('rewriteImagePaths', () => {
+  it('should prepend directory from file path to relative image src', () => {
+    const html = '<img alt="test" src="image.png">'
+    const result = rewriteImagePaths(html, 'dir/subdir/page.md')
+    expect(result).toBe('<img alt="test" src="/api/static/dir/subdir/image.png">')
+  })
+
+  it('should handle file at root level (no directory prefix)', () => {
+    const html = '<img alt="test" src="image.png">'
+    const result = rewriteImagePaths(html, 'page.md')
+    expect(result).toBe('<img alt="test" src="/api/static/image.png">')
+  })
+
+  it('should handle image with nested relative path', () => {
+    const html = '<img alt="test" src="assets/image.png">'
+    const result = rewriteImagePaths(html, 'docs/guide/page.md')
+    expect(result).toBe('<img alt="test" src="/api/static/docs/guide/assets/image.png">')
+  })
+
+  it('should not rewrite absolute URLs', () => {
+    const html = '<img alt="test" src="https://example.com/image.png">'
+    const result = rewriteImagePaths(html, 'dir/page.md')
+    expect(result).toBe('<img alt="test" src="https://example.com/image.png">')
+  })
+
+  it('should not rewrite paths starting with /', () => {
+    const html = '<img alt="test" src="/api/static/already/correct.png">'
+    const result = rewriteImagePaths(html, 'dir/page.md')
+    expect(result).toBe('<img alt="test" src="/api/static/already/correct.png">')
+  })
+
+  it('should handle multiple images', () => {
+    const html = '<img src="a.png"><img src="b.jpg">'
+    const result = rewriteImagePaths(html, 'docs/page.md')
+    expect(result).toBe('<img src="/api/static/docs/a.png"><img src="/api/static/docs/b.jpg">')
+  })
+
+  it('should add cache-busting parameter when requested', () => {
+    const html = '<img alt="test" src="image.png">'
+    const result = rewriteImagePaths(html, 'dir/page.md', true)
+    expect(result).toMatch(/src="\/api\/static\/dir\/image\.png\?t=\d+"/)
+  })
+})
+
+describe('isRelativeAssetLink', () => {
+  it('should return true for PDF links', () => {
+    expect(isRelativeAssetLink('document.pdf')).toBe(true)
+  })
+
+  it('should return true for image links', () => {
+    expect(isRelativeAssetLink('photo.jpg')).toBe(true)
+  })
+
+  it('should return true for nested asset paths', () => {
+    expect(isRelativeAssetLink('assets/doc.pdf')).toBe(true)
+  })
+
+  it('should return false for markdown links', () => {
+    expect(isRelativeAssetLink('page.md')).toBe(false)
+  })
+
+  it('should return false for markdown links with anchors', () => {
+    expect(isRelativeAssetLink('page.md#section')).toBe(false)
+  })
+
+  it('should return false for external URLs', () => {
+    expect(isRelativeAssetLink('https://example.com/doc.pdf')).toBe(false)
+    expect(isRelativeAssetLink('http://example.com/doc.pdf')).toBe(false)
+  })
+
+  it('should return false for anchor links', () => {
+    expect(isRelativeAssetLink('#section')).toBe(false)
+  })
+
+  it('should return false for empty string', () => {
+    expect(isRelativeAssetLink('')).toBe(false)
+  })
+
+  it('should return false for paths without extension', () => {
+    expect(isRelativeAssetLink('somefile')).toBe(false)
+  })
+})

--- a/frontend/src/utils/htmlRewriter.ts
+++ b/frontend/src/utils/htmlRewriter.ts
@@ -1,0 +1,58 @@
+/**
+ * Extracts the directory part from a file path.
+ * "dir/subdir/file.md" -> "dir/subdir"
+ * "file.md" -> ""
+ */
+export function getDirectory(filePath: string): string {
+  const lastSlash = filePath.lastIndexOf('/')
+  return lastSlash >= 0 ? filePath.substring(0, lastSlash) : ''
+}
+
+/**
+ * Rewrites relative image src attributes to use /api/static/ with the correct directory context.
+ * Images referenced relative to a markdown file need the file's directory prepended.
+ *
+ * Example: For file "docs/guide/page.md" with image src="diagram.png":
+ *   -> src="/api/static/docs/guide/diagram.png"
+ */
+export function rewriteImagePaths(html: string, filePath: string, cacheBust = false): string {
+  const dir = getDirectory(filePath)
+  const prefix = dir ? `${dir}/` : ''
+  const timestamp = cacheBust ? `?t=${Date.now()}` : ''
+
+  return html.replace(/<img([^>]*)\s+src="([^":/]+[^":]*)"/g, (_match, attrs, src) => {
+    // Only rewrite if it's a relative path (doesn't start with http://, https://, or /)
+    if (!src.startsWith('http://') && !src.startsWith('https://') && !src.startsWith('/')) {
+      return `<img${attrs} src="/api/static/${prefix}${src}${timestamp}"`
+    }
+    return _match
+  })
+}
+
+/**
+ * Checks if a link href is a relative asset link (not markdown, not external, not anchor).
+ * These are files like PDFs, images, etc. that should be served via /api/static/.
+ */
+export function isRelativeAssetLink(href: string): boolean {
+  if (!href) return false
+
+  // Exclude absolute URLs
+  if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')) {
+    return false
+  }
+
+  // Exclude anchors
+  if (href.startsWith('#')) {
+    return false
+  }
+
+  // Exclude markdown links (handled separately for in-app navigation)
+  if (href.endsWith('.md') || href.includes('.md#') || href.includes('.md?')) {
+    return false
+  }
+
+  // Must have a file extension to be considered an asset
+  const lastDot = href.lastIndexOf('.')
+  const lastSlash = href.lastIndexOf('/')
+  return lastDot > lastSlash && lastDot > 0
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -473,7 +473,7 @@ async fn handle_file_event(event: Event, state: &SharedMarkdownState) {
                         }
                         _ => {}
                     }
-                } else if path.is_file() && is_image_file(path.to_str().unwrap_or("")) {
+                } else if path.is_file() && is_servable_file(path.to_str().unwrap_or("")) {
                     match event.kind {
                         Modify(_) | Create(_) | Remove(_) => {
                             handle_image_change(state).await;
@@ -671,8 +671,8 @@ async fn api_serve_static(
     AxumPath(path): AxumPath<String>,
     State(state): State<SharedMarkdownState>,
 ) -> impl IntoResponse {
-    // Only serve image files for security
-    if !is_image_file(&path) {
+    // Only serve allowed file types for security
+    if !is_servable_file(&path) {
         return (
             StatusCode::NOT_FOUND,
             [(header::CONTENT_TYPE, "text/plain")],
@@ -698,7 +698,7 @@ async fn api_serve_static(
 
             match fs::read(&canonical_path) {
                 Ok(contents) => {
-                    let content_type = guess_image_content_type(&path);
+                    let content_type = guess_content_type(&path);
                     (
                         StatusCode::OK,
                         [(header::CONTENT_TYPE, content_type.as_str())],
@@ -727,7 +727,7 @@ async fn server_health() -> impl IntoResponse {
     (StatusCode::OK, "ready")
 }
 
-fn is_image_file(file_path: &str) -> bool {
+fn is_servable_file(file_path: &str) -> bool {
     let extension = std::path::Path::new(file_path)
         .extension()
         .and_then(|ext| ext.to_str())
@@ -735,11 +735,18 @@ fn is_image_file(file_path: &str) -> bool {
 
     matches!(
         extension.to_lowercase().as_str(),
-        "png" | "jpg" | "jpeg" | "gif" | "svg" | "webp" | "bmp" | "ico"
+        // Images
+        "png" | "jpg" | "jpeg" | "gif" | "svg" | "webp" | "bmp" | "ico" |
+        // Documents
+        "pdf" |
+        // Audio/Video
+        "mp3" | "mp4" | "ogg" | "wav" | "webm" |
+        // Fonts
+        "woff" | "woff2" | "ttf" | "otf" | "eot"
     )
 }
 
-fn guess_image_content_type(file_path: &str) -> String {
+fn guess_content_type(file_path: &str) -> String {
     let extension = std::path::Path::new(file_path)
         .extension()
         .and_then(|ext| ext.to_str())
@@ -753,6 +760,17 @@ fn guess_image_content_type(file_path: &str) -> String {
         "webp" => "image/webp",
         "bmp" => "image/bmp",
         "ico" => "image/x-icon",
+        "pdf" => "application/pdf",
+        "mp3" => "audio/mpeg",
+        "mp4" => "video/mp4",
+        "ogg" => "audio/ogg",
+        "wav" => "audio/wav",
+        "webm" => "video/webm",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
+        "ttf" => "font/ttf",
+        "otf" => "font/otf",
+        "eot" => "application/vnd.ms-fontobject",
         _ => "application/octet-stream",
     }
     .to_string()
@@ -821,10 +839,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_image_file() {
-        assert!(is_image_file("test.png"));
-        assert!(is_image_file("test.jpg"));
-        assert!(!is_image_file("test.txt"));
+    fn test_is_servable_file() {
+        assert!(is_servable_file("test.png"));
+        assert!(is_servable_file("test.jpg"));
+        assert!(is_servable_file("test.pdf"));
+        assert!(is_servable_file("test.mp4"));
+        assert!(!is_servable_file("test.txt"));
+        assert!(!is_servable_file("test.md"));
     }
 
     #[test]
@@ -1201,37 +1222,41 @@ mod tests {
     }
 
     #[test]
-    fn test_is_image_file_all_types() {
+    fn test_is_servable_file_all_types() {
         // Test all supported image types
-        assert!(is_image_file("test.png"));
-        assert!(is_image_file("test.PNG"));
-        assert!(is_image_file("test.jpg"));
-        assert!(is_image_file("test.jpeg"));
-        assert!(is_image_file("test.gif"));
-        assert!(is_image_file("test.svg"));
-        assert!(is_image_file("test.webp"));
-        assert!(is_image_file("test.bmp"));
-        assert!(is_image_file("test.ico"));
-        // Test non-image files
-        assert!(!is_image_file("test.txt"));
-        assert!(!is_image_file("test.md"));
-        assert!(!is_image_file("test"));
+        assert!(is_servable_file("test.png"));
+        assert!(is_servable_file("test.PNG"));
+        assert!(is_servable_file("test.jpg"));
+        assert!(is_servable_file("test.jpeg"));
+        assert!(is_servable_file("test.gif"));
+        assert!(is_servable_file("test.svg"));
+        assert!(is_servable_file("test.webp"));
+        assert!(is_servable_file("test.bmp"));
+        assert!(is_servable_file("test.ico"));
+        // Test document types
+        assert!(is_servable_file("test.pdf"));
+        // Test media types
+        assert!(is_servable_file("test.mp3"));
+        assert!(is_servable_file("test.mp4"));
+        // Test non-servable files
+        assert!(!is_servable_file("test.txt"));
+        assert!(!is_servable_file("test.md"));
+        assert!(!is_servable_file("test"));
     }
 
     #[test]
-    fn test_guess_image_content_type() {
-        assert_eq!(guess_image_content_type("test.png"), "image/png");
-        assert_eq!(guess_image_content_type("test.jpg"), "image/jpeg");
-        assert_eq!(guess_image_content_type("test.jpeg"), "image/jpeg");
-        assert_eq!(guess_image_content_type("test.gif"), "image/gif");
-        assert_eq!(guess_image_content_type("test.svg"), "image/svg+xml");
-        assert_eq!(guess_image_content_type("test.webp"), "image/webp");
-        assert_eq!(guess_image_content_type("test.bmp"), "image/bmp");
-        assert_eq!(guess_image_content_type("test.ico"), "image/x-icon");
-        assert_eq!(
-            guess_image_content_type("test.txt"),
-            "application/octet-stream"
-        );
+    fn test_guess_content_type() {
+        assert_eq!(guess_content_type("test.png"), "image/png");
+        assert_eq!(guess_content_type("test.jpg"), "image/jpeg");
+        assert_eq!(guess_content_type("test.jpeg"), "image/jpeg");
+        assert_eq!(guess_content_type("test.gif"), "image/gif");
+        assert_eq!(guess_content_type("test.svg"), "image/svg+xml");
+        assert_eq!(guess_content_type("test.webp"), "image/webp");
+        assert_eq!(guess_content_type("test.bmp"), "image/bmp");
+        assert_eq!(guess_content_type("test.ico"), "image/x-icon");
+        assert_eq!(guess_content_type("test.pdf"), "application/pdf");
+        assert_eq!(guess_content_type("test.mp4"), "video/mp4");
+        assert_eq!(guess_content_type("test.txt"), "application/octet-stream");
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -765,6 +765,61 @@ async fn test_api_static_supports_multiple_image_formats() {
     assert_eq!(response.header("content-type"), "image/webp");
 }
 
+#[tokio::test]
+async fn test_api_static_serves_pdf_successfully() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+
+    fs::write(temp_dir.path().join("test.md"), "# Test").expect("Failed to write markdown");
+
+    // Create a test PDF file (PDF magic bytes)
+    let pdf_bytes = b"%PDF-1.4 test content";
+    fs::write(temp_dir.path().join("doc.pdf"), pdf_bytes).expect("Failed to write pdf");
+
+    let base_dir = temp_dir.path().to_path_buf();
+    let tracked_files = scan_markdown_files(&base_dir).expect("Failed to scan");
+    let router = new_router(base_dir, tracked_files, true).expect("Failed to create router");
+    let server = TestServer::new(router).expect("Failed to create server");
+
+    let response = server.get("/api/static/doc.pdf").await;
+    assert_eq!(response.status_code(), 200);
+    assert_eq!(response.header("content-type"), "application/pdf");
+    assert_eq!(response.as_bytes().as_ref(), pdf_bytes);
+}
+
+#[tokio::test]
+async fn test_api_static_serves_assets_in_subdirectories() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+
+    // Create a subdirectory structure like: subdir/nested/
+    let nested_dir = temp_dir.path().join("subdir").join("nested");
+    fs::create_dir_all(&nested_dir).expect("Failed to create nested dir");
+
+    fs::write(nested_dir.join("test.md"), "# Test").expect("Failed to write markdown");
+
+    // Create an image in the subdirectory
+    let png_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    fs::write(nested_dir.join("image.png"), &png_bytes).expect("Failed to write image");
+
+    // Create a PDF in the subdirectory
+    let pdf_bytes = b"%PDF-1.4 test";
+    fs::write(nested_dir.join("doc.pdf"), pdf_bytes).expect("Failed to write pdf");
+
+    let base_dir = temp_dir.path().to_path_buf();
+    let tracked_files = scan_markdown_files(&base_dir).expect("Failed to scan");
+    let router = new_router(base_dir, tracked_files, true).expect("Failed to create router");
+    let server = TestServer::new(router).expect("Failed to create server");
+
+    // Image in subdirectory should be accessible
+    let response = server.get("/api/static/subdir/nested/image.png").await;
+    assert_eq!(response.status_code(), 200);
+    assert_eq!(response.header("content-type"), "image/png");
+
+    // PDF in subdirectory should be accessible
+    let response = server.get("/api/static/subdir/nested/doc.pdf").await;
+    assert_eq!(response.status_code(), 200);
+    assert_eq!(response.header("content-type"), "application/pdf");
+}
+
 // ============================================================================
 // WebSocket Message Type Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- **Image paths now include directory context**: Images referenced with relative paths in markdown (e.g., `![alt](image.png)` inside `docs/guide/page.md`) are now correctly resolved to `/api/static/docs/guide/image.png` instead of `/api/static/image.png`
- **Non-image assets (PDFs, media, fonts) are now served**: The `/api/static/` endpoint previously only served images; it now supports PDFs, audio/video, and font files
- **Relative asset links in markdown are rewritten**: `<a href="doc.pdf">` links are rewritten to point to `/api/static/{dir}/doc.pdf` and open in a new tab

## Test plan
- [x] Backend: `test_api_static_serves_pdf_successfully` - PDF serving returns 200 with correct content-type
- [x] Backend: `test_api_static_serves_assets_in_subdirectories` - images and PDFs in nested dirs are accessible
- [x] Frontend: 20 tests in `htmlRewriter.test.ts` covering directory extraction, image path rewriting with directory context, cache-busting, and asset link detection
- [x] Frontend: 5 tests in `MarkdownContent.test.tsx` for relative asset link rewriting (PDFs, nested paths, external URL exclusion, new-tab behavior)
- [x] All 179 frontend tests pass, all 35 backend tests pass
- [x] End-to-end verified against a real markdown project with images and PDFs in subdirectories